### PR TITLE
Fix #8 - Use big endian by default instead of little endian

### DIFF
--- a/source/agora/serialization/Serializer.d
+++ b/source/agora/serialization/Serializer.d
@@ -292,13 +292,14 @@ private enum hasFromBinaryFunction (T) = is(T == struct)
         T       = Top level type of data
         record  = Data to serialize
         buffer  = The buffer to reset then write to.
+        compact = Whether integers are serialized in variable-length form
 
     Returns:
         A reference to `buffer` after serialization
 
 *******************************************************************************/
 
-public ubyte[] serializeToBuffer (T) (in T record, scope return ref ubyte[] buffer)
+public ubyte[] serializeToBuffer (T) (in T record, scope return ref ubyte[] buffer, CompactMode compact = CompactMode.Yes)
     @safe
 {
     buffer.length = 0;
@@ -307,7 +308,7 @@ public ubyte[] serializeToBuffer (T) (in T record, scope return ref ubyte[] buff
     {
         buffer ~= data;
     };
-    serializePart(record, dg);
+    serializePart(record, dg, compact);
     return buffer;
 }
 
@@ -357,11 +358,11 @@ unittest
 
 *******************************************************************************/
 
-public ubyte[] serializeFull (T) (in T record)
+public ubyte[] serializeFull (T) (in T record, CompactMode compact = CompactMode.Yes)
     @safe
 {
     ubyte[] buffer;
-    return serializeToBuffer(record, buffer);
+    return serializeToBuffer(record, buffer, compact);
 }
 
 ///

--- a/source/agora/serialization/Serializer.d
+++ b/source/agora/serialization/Serializer.d
@@ -19,7 +19,7 @@
     ---
     struct Foo
     {
-         void serialize(scope SerializeDg) const @safe;
+         void serialize (scope SerializeDg sink) const @safe;
     }
     ---
     The return type can be of another type, and other attributes
@@ -33,7 +33,7 @@
     struct Foo
     {
         static T fromBinary (T) (scope DeserializeDg data,
-            in DeserializerOptions) @safe;
+            in DeserializerOptions opts) @safe;
     }
     ---
     The deserializer might request an instance of a `const` or `immutable`


### PR DESCRIPTION
```
Network byte order, and the IETF in general, is big endian,
while Intel went with little endian CPU.
As binary serialization can be used mostly for disk serialization
and network communication, it doesn't make much difference in the first
case, and makes a whole lot of difference in the second.
Instead of allowing the user to choose the byte order,
as suggested in issue 8, we simply change it to big endian by default,
as there is currently no foreseen use case for little endian.
```

A few other improvements were made along the way.