### PR TITLE
Fix building in non-unittest mode

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -7,7 +7,16 @@
     "copyright": "Copyright © 2021, BOSAGORA Foundation",
 
     "targetType": "library",
-    "dflags": [ "-checkaction=context" ],
+
+    "configurations": [
+        {
+            "name": "library"
+        },
+        {
+            "name": "unittest",
+            "dflags": [ "-checkaction=context" ]
+        }
+    ],
 
     "dependencies": {
         "bitblob": "~>1.1"


### PR DESCRIPTION
Unfortunately using a simple 'dflags' means that this gets passed to release as well,
which triggers a cascade of link error.