### PR TITLE
Remove BitBlob dependency on normal/unittest build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
       if: runner.os != 'Windows'
       run: |
         dub test --compiler=$DC
+        dub test -c unittest-with-deps --compiler=$DC
 
     - name: '[Windows] Build & test'
       if: runner.os == 'Windows'
@@ -35,6 +36,8 @@ jobs:
       run: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         dub test --compiler=${{ env.DC }}
+        if %errorlevel% neq 0 exit /b %errorlevel%
+        dub test -c unittest-with-deps --compiler=${{ env.DC }}
         if %errorlevel% neq 0 exit /b %errorlevel%
 
     - name: 'Upload code coverage'

--- a/dub.json
+++ b/dub.json
@@ -15,10 +15,13 @@
         {
             "name": "unittest",
             "dflags": [ "-checkaction=context" ]
+        },
+        {
+            "name": "unittest-with-deps",
+            "dflags": [ "-checkaction=context" ],
+            "dependencies": {
+                "bitblob": "~>1.1"
+            }
         }
-    ],
-
-    "dependencies": {
-        "bitblob": "~>1.1"
-    }
+    ]
 }

--- a/source/agora/serialization/Serializer.d
+++ b/source/agora/serialization/Serializer.d
@@ -712,7 +712,7 @@ unittest
 }
 
 // Make sure BitBlobs are serialized without length
-unittest
+version (Have_bitblob) unittest
 {
     import geod24.bitblob;
 


### PR DESCRIPTION
The BitBlob dependency was only used for a test, and is not actually needed.
However, it is useful for testing purpose, but shouldn't be brought in
when the user uses the 'unittest' configuration,
so we introduce a special configuration for serialization itself.