### PR TITLE
Pointer serialization: Make it match deserialization code

### DIFF
--- a/source/agora/serialization/Serializer.d
+++ b/source/agora/serialization/Serializer.d
@@ -445,11 +445,13 @@ public void serializePart (T) (in T record, scope SerializeDg dg,
     // Pointers are handled as arrays, only their size must be 0 or 1
     else static if (is(T : E*, E))
     {
+        ubyte[1] len;
         if (record is null)
-            toVarInt(uint(0), dg);
+            dg(len[]); // Default to 0
         else
         {
-            toVarInt(uint(1), dg);
+            len[0] = 1;
+            dg(len);
             serializePart(*record, dg, compact);
         }
     }


### PR DESCRIPTION
The pointer deserialization code reads a single ubyte, while the serialization code
was doing variable-length encoding on the values 1 or 0 typed as uint.
Since the values are always under the threshold where the encoding kicks in,
it was functionally equivalent, but the new code should be a bit clearer on that.